### PR TITLE
Update version file URL to current repo owner

### DIFF
--- a/GameData/NearFutureSpacecraft/Versioning/NearFutureSpacecraft.version
+++ b/GameData/NearFutureSpacecraft/Versioning/NearFutureSpacecraft.version
@@ -1,6 +1,6 @@
 {
     "NAME":"NearFutureSpacecraft",
-    "URL":"https://raw.githubusercontent.com/ChrisAdderley/NearFutureSpacecraft/master/GameData/NearFutureSpacecraft/Versioning/NearFutureSpacecraft.version",
+    "URL":"https://raw.githubusercontent.com/post-kerbin-mining-corporation/NearFutureSpacecraft/master/GameData/NearFutureSpacecraft/Versioning/NearFutureSpacecraft.version",
     "DOWNLOAD":"http://forum.kerbalspaceprogram.com/index.php?/topic/155465-122-near-future-technologies",
     "VERSION":
     {


### PR DESCRIPTION
Hi @ChrisAdderley,

The URLs in this mod's version file are slightly out of date, they still have the previous repo owner. GitHub helpfully silently redirects them, so they still work, but this can sometimes trrigger GitHub's server-side rate limiting behavior.

Now they're updated to the latest correct values.